### PR TITLE
Unit testability

### DIFF
--- a/src/TodoApp/Maths.cs
+++ b/src/TodoApp/Maths.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace TodoApp;
+
+public static class Maths
+{
+    public static JsonHttpResult<int> Add(int x, int y)
+        => TypedResults.Json(x + y);
+
+    public static JsonHttpResult<int> Multiply(int x, int y)
+        => TypedResults.Json(x * y);
+}

--- a/src/TodoApp/SampleEndpoints.cs
+++ b/src/TodoApp/SampleEndpoints.cs
@@ -284,7 +284,8 @@ public static class SampleEndpoints
             // https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-7-preview-4/#openapi-improvements-for-minimal-apis
             samples.MapGet("/{x:int}/add/{y:int}", Maths.Add)
                    .WithSummary("Add two integers")
-                   .WithDescription("Adds two integers and returns their sum");
+                   .WithDescription("Adds two integers and returns their sum")
+                   .WithTags("Maths");
 
             samples.MapGet("/{x:int}/multiply/{y:int}", Maths.Multiply)
                    .WithOpenApi(operation =>

--- a/src/TodoApp/SampleEndpoints.cs
+++ b/src/TodoApp/SampleEndpoints.cs
@@ -282,11 +282,11 @@ public static class SampleEndpoints
             // Samples for OpenAPI improvements
             // https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-7-preview-2/#provide-endpoint-descriptions-and-summaries-for-minimal-apis
             // https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-7-preview-4/#openapi-improvements-for-minimal-apis
-            samples.MapGet("/{x:int}/add/{y:int}", (int x, int y) => new { sum = x + y })
+            samples.MapGet("/{x:int}/add/{y:int}", Maths.Add)
                    .WithSummary("Add two integers")
                    .WithDescription("Adds two integers and returns their sum");
 
-            samples.MapGet("/{x:int}/multiply/{y:int}", (int x, int y) => new { product = x * y })
+            samples.MapGet("/{x:int}/multiply/{y:int}", Maths.Multiply)
                    .WithOpenApi(operation =>
                    {
                        operation.Summary = "Multiplies two integers";

--- a/tests/TodoApp.Tests/MathsTests.cs
+++ b/tests/TodoApp.Tests/MathsTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace TodoApp;
+
+// Samples for improved unit testability
+// https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-7-preview-3/#improved-unit-testability-for-minimal-route-handlers
+
+public static class MathsTests
+{
+    [Theory]
+    [InlineData(1, 2, 3)]
+    [InlineData(37, 42, 79)]
+    [InlineData(1138, 0, 1138)]
+    public static void Can_Add_Numbers(int x, int y, int expected)
+    {
+        // Act
+        JsonHttpResult<int> result = Maths.Add(x, y);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(1, 2, 2)]
+    [InlineData(37, 42, 1554)]
+    [InlineData(1138, 0, 0)]
+    public static void Can_Multiply_Numbers(int x, int y, int expected)
+    {
+        // Act
+        JsonHttpResult<int> result = Maths.Multiply(x, y);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
- Refactor two endpoints to use a handler class and method, rather than a lambda, to show the unit testing improvements.
- Add `WithTags()` to an endpoint.
